### PR TITLE
Also push to OSG Harbor (SOFTWARE-4718)

### DIFF
--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -38,8 +38,13 @@ jobs:
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
         docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
-        tag_list=$docker_repo:$REPO,$docker_repo:$REPO-$TIMESTAMP
-        echo "::set-output name=taglist::$tag_list"
+        tag_list=()
+        for registry in hub.opensciencegrid.org/ ''; do
+          for image_tag in "$REPO" "$REPO-$TIMESTAMP"; do
+            tag_list+=("$registry$docker_repo":"$image_tag")
+          done
+        done
+        echo "::set-output name=taglist::${tag_list[*]}"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -49,6 +54,13 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Log in to OSG Harbor
+      uses: docker/login-action@v1
+      with:
+        registry: hub.opensciencegrid.org
+        username: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+        password: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
 
     - name: Build and push Docker images
       uses: docker/build-push-action@v2.2.0

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -39,9 +39,9 @@ jobs:
       run: |
         docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
         tag_list=()
-        for registry in hub.opensciencegrid.org/ ''; do
+        for registry in hub.opensciencegrid.org docker.io; do
           for image_tag in "$REPO" "$REPO-$TIMESTAMP"; do
-            tag_list+=("$registry$docker_repo":"$image_tag")
+            tag_list+=("$registry/$docker_repo":"$image_tag")
           done
         done
         echo "::set-output name=taglist::${tag_list[*]}"


### PR DESCRIPTION
I tested as much as I could locally but ended up getting stuck on my personal fork. This should be everything we need, though: a step logging into our Harbor instance and adding the Harbor registry to the tag list.

Separately, @edquist I really wanted to just do something like the following but I got a lot of extra `::set-output...` strings:

```
$ docker_repo=opensciencegrid/xrootd-standalone
$ REPO=release
$ TIMESTAMP=now
$ echo "::set-output name=taglist::"{hub.opensciencegrid.org/,}$docker_repo:$REPO{,-$TIMESTAMP}
::set-output name=taglist::hub.opensciencegrid.org/opensciencegrid/xrootd-standalone:release ::set-output name=taglist::hub.opensciencegrid.org/opensciencegrid/xrootd-standalone:release-now ::set-output name=taglist::opensciencegrid/xrootd-standalone:release ::set-output name=taglist::opensciencegrid/xrootd-standalone:release-now
```

