### PR TITLE
Separate out docker registries while keeping old yml (SOFTWARE-4823)

### DIFF
--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -30,10 +30,12 @@ jobs:
       matrix:
         repo: ['development', 'testing', 'release']
         registries:
-          - url: hub.opensciencegrid.org
+          - name: OSG Harbor
+            url: hub.opensciencegrid.org
             username: OSG_HARBOR_ROBOT_USER
             password: OSG_HARBOR_ROBOT_PASSWORD
-          - url: docker.io
+          - name: Docker Hub
+            url: docker.io
             username: DOCKER_USERNAME
             password: DOCKER_PASSWORD
 
@@ -53,11 +55,12 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Log in to Docker Hub
+    - name: Log in to ${{ matrix.registries.name }}
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: ${{ matrix.registry.url }}
+        username: ${{ secrets[matrix.registries.username] }}
+        password: ${{ secrets[matrix.registries.password] }}
 
     - name: Build and push Docker images
       uses: docker/build-push-action@v2.2.0

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -33,7 +33,7 @@ jobs:
           - url: hub.opensciencegrid.org
             username: OSG_HARBOR_ROBOT_USER
             password: OSG_HARBOR_ROBOT_PASSWORD
-          - url: hub.opensciencegrid.org
+          - url: docker.io
             username: DOCKER_USERNAME
             password: DOCKER_PASSWORD
 

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - SOFTWARE-4832
   repository_dispatch:
     types:
       - dispatch-build
@@ -13,7 +12,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: startsWith(github.repository, 'yongleyuan/')
+    if: startsWith(github.repository, 'opensciencegrid/')
     strategy:
       fail-fast: False
       matrix:

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -28,13 +28,11 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        name:
-          - name1
-          - name2
-        repo:
-          - 'development'
-          - 'testing'
-          - 'release'
+        registries:
+          - name: name1
+            repo: 'development'
+          - name: name2
+            repo: 'testing'
 
     steps:
 

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -10,18 +10,29 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  make-date-tag:
     runs-on: ubuntu-latest
     if: startsWith(github.repository, 'opensciencegrid/')
+    outputs:
+      dtag: ${{ steps.mkdatetag.outputs.dtag }}
+    steps:
+    - name: make date tag
+      id: mkdatetag
+      run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [make-date-tag]
+    if: startsWith(github.repository, 'yongleyuan/')
     strategy:
       fail-fast: False
       matrix:
         repo: ['development', 'testing', 'release']
-        registry:
+        registries:
           - url: hub.opensciencegrid.org
             username: OSG_HARBOR_ROBOT_USER
             password: OSG_HARBOR_ROBOT_PASSWORD
-          - url: docker.io
+          - url: hub.opensciencegrid.org
             username: DOCKER_USERNAME
             password: DOCKER_PASSWORD
 
@@ -29,10 +40,27 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Push container
-      uses: yongleyuan/push-container-action@v1
+    - id: generate-tag-list
+      env:
+        REPO: ${{ matrix.repo }}
+        TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
+      run: |
+        docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
+        tag_list=$docker_repo:$REPO,$docker_repo:$REPO-$TIMESTAMP
+        echo "::set-output name=taglist::$tag_list"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1
       with:
-        repo: ${{ matrix.repo }}
-        registry_url: ${{ matrix.registry.url }}
-        registry_user: ${{ secrets[matrix.registry.username] }}
-        registry_pass: ${{ secrets[matrix.registry.password] }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2.2.0
+      with:
+        push: true
+        build-args: BASE_YUM_REPO=${{ matrix.repo }}
+        tags: "${{ steps.generate-tag-list.outputs.taglist }}"

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -30,10 +30,12 @@ jobs:
       matrix:
         repo: ['development', 'testing', 'release']
         registries:
-          - name: name1
-            username: u1
-          - name: name2
-            username: u2
+          - url: hub.opensciencegrid.org
+            username: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
+            password: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+          - url: hub.opensciencegrid.org
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
 
     steps:
 

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         repo: ['development', 'testing', 'release']
         registry:
-          - name: OSG Harbor
+          - url: hub.opensciencegrid.org
             username: OSG_HARBOR_ROBOT_USER
             password: OSG_HARBOR_ROBOT_PASSWORD
-          - name: Docker Hub
+          - url: docker.io
             username: DOCKER_USERNAME
             password: DOCKER_PASSWORD
 
@@ -34,6 +34,6 @@ jobs:
       uses: yongleyuan/push-container-action@v1
       with:
         repo: ${{ matrix.repo }}
-        registry_name: ${{ matrix.registry.name }}
-        username: ${{ secrets[matrix.registry.username] }}
-        password: ${{ secrets[matrix.registry.password] }}
+        registry_url: ${{ matrix.registry.url }}
+        registry_user: ${{ secrets[matrix.registry.username] }}
+        registry_pass: ${{ secrets[matrix.registry.password] }}

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -28,7 +28,10 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        repo: ['development', 'testing', 'release']
+        repo:
+          - 'development'
+          - 'testing'
+          - 'release'
 
     steps:
 

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -11,31 +11,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  make-date-tag:
-    runs-on: ubuntu-latest
-    if: startsWith(github.repository, 'yongleyuan/')
-    outputs:
-      dtag: ${{ steps.mkdatetag.outputs.dtag }}
-    steps:
-    - name: make date tag
-      id: mkdatetag
-      run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
-
   build:
     runs-on: ubuntu-latest
-    needs: [make-date-tag]
     if: startsWith(github.repository, 'yongleyuan/')
     strategy:
       fail-fast: False
       matrix:
         repo: ['development', 'testing', 'release']
-        registries:
+        registry:
           - name: OSG Harbor
-            url: hub.opensciencegrid.org
             username: OSG_HARBOR_ROBOT_USER
             password: OSG_HARBOR_ROBOT_PASSWORD
           - name: Docker Hub
-            url: docker.io
             username: DOCKER_USERNAME
             password: DOCKER_PASSWORD
 
@@ -43,35 +30,10 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - id: generate-tag-list
-      env:
-        REPO: ${{ matrix.repo }}
-        TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
-      run: |
-        docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
-        tag_list=()
-        for registry in hub.opensciencegrid.org docker.io; do
-          for image_tag in "$REPO" "$REPO-$TIMESTAMP"; do
-            tag_list+=("$registry/$docker_repo":"$image_tag")
-          done
-        done
-        IFS=,
-        echo $tag_list
-        echo "::set-output name=taglist::${tag_list[*]}"
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Log in to ${{ matrix.registries.name }}
-      uses: docker/login-action@v1
+    - name: Push container
+      uses: yongleyuan/push-container-action@v1
       with:
-        registry: ${{ matrix.registry.url }}
-        username: ${{ secrets[matrix.registries.username] }}
-        password: ${{ secrets[matrix.registries.password] }}
-
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v2.2.0
-      with:
-        push: true
-        build-args: BASE_YUM_REPO=${{ matrix.repo }}
-        tags: "${{ steps.generate-tag-list.outputs.taglist }}"
+        repo: ${{ matrix.repo }}
+        registry_name: ${{ matrix.registry.name }}
+        username: ${{ secrets[matrix.registry.username] }}
+        password: ${{ secrets[matrix.registry.password] }}

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -28,6 +28,9 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
+        name:
+          - name1
+          - name2
         repo:
           - 'development'
           - 'testing'

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -28,11 +28,12 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
+        repo: ['development', 'testing', 'release']
         registries:
           - name: name1
-            repo: 'development'
+            username: u1
           - name: name2
-            repo: 'testing'
+            username: u2
 
     steps:
 

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -49,8 +49,15 @@ jobs:
         TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
       run: |
         docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
-        tag_list=$docker_repo:$REPO,$docker_repo:$REPO-$TIMESTAMP
-        echo "::set-output name=taglist::$tag_list"
+        tag_list=()
+        for registry in hub.opensciencegrid.org docker.io; do
+          for image_tag in "$REPO" "$REPO-$TIMESTAMP"; do
+            tag_list+=("$registry/$docker_repo":"$image_tag")
+          done
+        done
+        IFS=,
+        echo $tag_list
+        echo "::set-output name=taglist::${tag_list[*]}"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -31,11 +31,11 @@ jobs:
         repo: ['development', 'testing', 'release']
         registries:
           - url: hub.opensciencegrid.org
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
+            username: OSG_HARBOR_ROBOT_USER
+            password: OSG_HARBOR_ROBOT_PASSWORD
           - url: hub.opensciencegrid.org
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
+            username: DOCKER_USERNAME
+            password: DOCKER_PASSWORD
 
     steps:
 
@@ -56,8 +56,8 @@ jobs:
     - name: Log in to Docker Hub
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets[matrix.username] }}
+        password: ${{ secrets[matrix.password] }}
 
     - name: Build and push Docker images
       uses: docker/build-push-action@v2.2.0

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - SOFTWARE-4832
   repository_dispatch:
     types:
       - dispatch-build

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   make-date-tag:
     runs-on: ubuntu-latest
-    if: startsWith(github.repository, 'opensciencegrid/')
+    if: startsWith(github.repository, 'yongleyuan/')
     outputs:
       dtag: ${{ steps.mkdatetag.outputs.dtag }}
     steps:
@@ -23,11 +23,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [make-date-tag]
-    if: startsWith(github.repository, 'opensciencegrid/')
+    if: startsWith(github.repository, 'yongleyuan/')
     strategy:
       fail-fast: False
       matrix:
         repo: ['development', 'testing', 'release']
+
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -31,8 +31,8 @@ jobs:
         repo: ['development', 'testing', 'release']
         registries:
           - url: hub.opensciencegrid.org
-            username: ${{ secrets.OSG_HARBOR_ROBOT_USER }}
-            password: ${{ secrets.OSG_HARBOR_ROBOT_PASSWORD }}
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
           - url: hub.opensciencegrid.org
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-sw-container.yml
+++ b/.github/workflows/build-sw-container.yml
@@ -56,8 +56,8 @@ jobs:
     - name: Log in to Docker Hub
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets[matrix.username] }}
-        password: ${{ secrets[matrix.password] }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build and push Docker images
       uses: docker/build-push-action@v2.2.0

--- a/.github/workflows/composite-build-sw-container.yml
+++ b/.github/workflows/composite-build-sw-container.yml
@@ -1,0 +1,38 @@
+name: Build container images
+
+on:
+  push:
+    branches:
+      - master
+  repository_dispatch:
+    types:
+      - dispatch-build
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: startsWith(github.repository, 'opensciencegrid/')
+    strategy:
+      fail-fast: False
+      matrix:
+        repo: ['development', 'testing', 'release']
+        registry:
+          - url: hub.opensciencegrid.org
+            username: OSG_HARBOR_ROBOT_USER
+            password: OSG_HARBOR_ROBOT_PASSWORD
+          - url: docker.io
+            username: DOCKER_USERNAME
+            password: DOCKER_PASSWORD
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Push container
+      uses: opensciencegrid/push-container-action@v1
+      with:
+        repo: ${{ matrix.repo }}
+        registry_url: ${{ matrix.registry.url }}
+        registry_user: ${{ secrets[matrix.registry.username] }}
+        registry_pass: ${{ secrets[matrix.registry.password] }}


### PR DESCRIPTION
This is similar to [this PR](https://github.com/opensciencegrid/docker-xrootd-standalone/pull/18) but keeping the old yml. The yml that uses composite run step is now named `composite-build-sw-container`.